### PR TITLE
chore: bump Solidity to 0.8.25

### DIFF
--- a/contracts/StatefulSponge.sol
+++ b/contracts/StatefulSponge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { LibKeccak } from "contracts/lib/LibKeccak.sol";
 

--- a/contracts/lib/LibKeccak.sol
+++ b/contracts/lib/LibKeccak.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 /// @title LibKeccak
 /// @notice An EVM implementation of the Keccak-f[1600] permutation.

--- a/test/LibKeccak.t.sol
+++ b/test/LibKeccak.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity 0.8.25;
 
 import { Test, console2 as console } from "forge-std/Test.sol";
 import { TestPlus } from "@solady-test/utils/TestPlus.sol";


### PR DESCRIPTION
Bumps the Solidity version to 0.8.25. Starting work on a larger migration of the entire Solidity codebase to 0.8.25 and this is one of the holdouts.
