### PR TITLE
maint: make solidity version loose

### DIFF
--- a/contracts/StatefulSponge.sol
+++ b/contracts/StatefulSponge.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 import { LibKeccak } from "contracts/lib/LibKeccak.sol";
 

--- a/contracts/lib/LibKeccak.sol
+++ b/contracts/lib/LibKeccak.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.15;
+pragma solidity ^0.8.0;
 
 /// @title LibKeccak
 /// @notice An EVM implementation of the Keccak-f[1600] permutation.


### PR DESCRIPTION
Updates the Solidity version being used here to a loose 0.8.0 version so that users of this contract can select their own Solidity version.